### PR TITLE
fix: make input area auto-resizable

### DIFF
--- a/components/ui/form-component.tsx
+++ b/components/ui/form-component.tsx
@@ -634,8 +634,20 @@ const FormComponent: React.FC<FormComponentProps> = ({
     const postSubmitFileInputRef = useRef<HTMLInputElement>(null);
     const [isFocused, setIsFocused] = useState(false);
 
+    const autoResizeInput = (target: HTMLTextAreaElement) => {
+        if (target) {
+            target.style.height = 'auto'; // trigger recalculate scrollHeight
+            let additionalLineHeight = 0;
+            if (target.value) {
+                additionalLineHeight = parseFloat(window.getComputedStyle(target).lineHeight);
+            }
+            target.style.height = `${target.scrollHeight + additionalLineHeight}px`;
+        }
+    };
+
     const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         setInput(event.target.value);
+        autoResizeInput(event.target);
     };
 
     const handleFocus = () => {
@@ -800,7 +812,7 @@ const FormComponent: React.FC<FormComponentProps> = ({
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     className={cn(
-                        "min-h-[40px] max-h-[200px] w-full resize-none rounded-lg",
+                        "min-h-[40px] w-full resize-none rounded-lg",
                         "overflow-y-auto overflow-x-hidden",
                         "text-base leading-relaxed",
                         "bg-neutral-100 dark:bg-neutral-900",


### PR DESCRIPTION
Fixes #31 

I added an additional call when handling user input to recalculate the layout and set the textarea's height properly. This will allow the textarea to grow/shrink properly as the user enters text.

Here's the demo video of the fix:

https://github.com/user-attachments/assets/6948b43c-6923-4a99-9feb-8cf0268445c2


