### PR TITLE
Fix styling in loading states

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2481,8 +2481,8 @@ Grok 2 models are now available for you to try out.
                 <div className="relative mt-4 px-0">
                     {/* Overlay with Loading Text */}
                     <div className="absolute inset-0 z-10 flex items-center justify-center">
-                        <div className="backdrop-blur-sm bg-white/30 dark:bg-black/30 rounded-2xl px-6 py-3 shadow-lg">
-                            <div className="flex items-center gap-2 text-sm font-medium text-neutral-600 dark:text-neutral-300">
+                        <div className="backdrop-blur-sm bg-white/30 dark:bg-black/30 rounded-xl px-4 h-full py-3 shadow-lg">
+                            <div className="flex items-center gap-2 text-sm font-medium text-neutral-600 h-full dark:text-neutral-300">
                                 <Loader2 className="w-4 h-4 animate-spin" />
                                 <span>Loading trending queries</span>
                             </div>
@@ -2490,7 +2490,7 @@ Grok 2 models are now available for you to try out.
                     </div>
 
                     {/* Background Cards */}
-                    <div className="flex gap-2">
+                    <div className="flex justify-between">
                         {[1, 2, 3].map((_, index) => (
                             <div
                                 key={index}

--- a/components/ui/form-component.tsx
+++ b/components/ui/form-component.tsx
@@ -770,7 +770,7 @@ const FormComponent: React.FC<FormComponentProps> = ({
                 </div>
             )}
 
-            <div className="relative">
+            <div className="relative rounded-lg bg-neutral-100 dark:bg-neutral-900">
                 <Textarea
                     ref={inputRef}
                     placeholder={hasSubmitted ? "Ask a new question..." : "Ask a question..."}


### PR DESCRIPTION
Fixed the opacity issue on the message form component in the loading state.

| Before           | After            |
|-------------------|------------------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/c0796d48-d8f8-4e39-9405-d88b0b77780f" /> | <img width="1512" alt="image" src="https://github.com/user-attachments/assets/bf763d07-217b-4c7e-a83a-79857176dfb1" /> |

Fixed the height of the loading message component and resolved the issue of skeleton cards overflowing parent width.
| Before           | After            |
|-------------------|------------------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/8d361ad5-0b08-40da-b819-9d9751e9d75f" /> | <img width="1512" alt="image" src="https://github.com/user-attachments/assets/66f492d9-45a8-4c91-8793-2b52ddf0c8c2" /> |

